### PR TITLE
Add a field to keep the original subject

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -14,13 +14,14 @@ const (
 
 // ClientCert is a client certificate passed to Envoy
 type ClientCert struct {
-	By      string
-	Hash    string
-	Cert    string
-	Chain   string
-	Subject *pkix.Name
-	URI     []string
-	DNS     []string
+	By         string
+	Hash       string
+	Cert       string
+	Chain      string
+	Subject    *pkix.Name
+	SubjectRaw string
+	URI        []string
+	DNS        []string
 }
 
 // ParseXFCCHeader parses an x-forwarded-client-cert header and returns the list of certificates present.
@@ -55,6 +56,7 @@ func ParseXFCCHeader(header string) ([]*ClientCert, error) {
 					return nil, fmt.Errorf("invalid subject in client cert %d: %v", i, err)
 				}
 				cert.Subject = subject
+				cert.SubjectRaw = field.Value
 			case "URI":
 				cert.URI = append(cert.URI, field.Value)
 			case "DNS":

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,6 +29,7 @@ func TestParseXFCCHeader(t *testing.T) {
 						OrganizationalUnit: []string{"hello"},
 						Organization:       []string{"Acme, Inc."},
 					},
+					SubjectRaw: `CN=hello,OU=hello,O=Acme\, Inc.`,
 					DNS: []string{"hello.west.example.com", "hello.east.example.com"},
 				},
 				{


### PR DESCRIPTION
There are times when we need the subject in its original form with all its fields in the same order as in the input string.
Converting `pkix.Name` to string does not always work because there are different specifications about the order of the subject fields and there are people who don't follow specifications. 

This simple addition will help immensely in that regard. 